### PR TITLE
First commit of ADSArxiv direct_ingest_pipeline worker with test cases

### DIFF
--- a/ADSArxiv/arxivmsg.py
+++ b/ADSArxiv/arxivmsg.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 
-from kombu import Queue
-from adsmsg import BibRecord, DenormalizedRecord
+from adsmsg import DenormalizedRecord
 from ADSArxiv.tasks import task_output_results
 from ADSArxiv.app import AdsArxivCelery
 
@@ -29,6 +28,3 @@ class ArxivToMasterPipeline(dict):
             task_output_results.delay(rec)
         else:
             print ("Null record, not sending to master pipeline")
-
-app = AdsArxivCelery('arxiv_pipeline')
-logger = app.logger

--- a/ADSArxiv/tasks.py
+++ b/ADSArxiv/tasks.py
@@ -1,14 +1,11 @@
-from __future__ import absolute_import, unicode_literals
-import ADSArxiv.app as app_module
-from adsputils import get_date, exceptions
 from kombu import Queue
 import os
-from adsmsg import DenormalizedRecord
+import app as app_module
 
-# ============================= INITIALIZATION ==================================== #
+# ============================== INITIALIZATION ============================== #
 
 proj_home = os.path.realpath(os.path.join(os.path.dirname(__file__), '../'))
-app = app_module.AdsArxivCelery('arxiv_pipeline', proj_home=proj_home)
+app = app_module.AdsArxivCelery('direct_ingest_pipeline', proj_home=proj_home)
 logger = app.logger
 
 
@@ -17,7 +14,7 @@ app.conf.CELERY_QUEUES = (
 )
 
 
-# ============================= TASKS ============================================= #
+# =============================== TASKS ====================================== #
 
 
 @app.task(queue='output-results')
@@ -36,7 +33,3 @@ def task_output_results(msg):
     """
     logger.debug('Will forward this nonbib record: %s', msg)
     app.forward_message(msg)
-
-
-if __name__ == '__main__':
-    app.start()

--- a/ADSArxiv/tests/test_app.py
+++ b/ADSArxiv/tests/test_app.py
@@ -1,0 +1,71 @@
+import unittest
+import sys, os
+import glob
+import json
+from mock import patch
+from pyingest.parsers import arxiv
+from ADSArxiv import arxivmsg
+from ADSArxiv import tasks
+from ADSArxiv import app as app_module
+
+ONEREC_STD = {'bibcode': u'2011arXiv1111.0262T', u'keyword': [u'Astrophysics - Solar and Stellar Astrophysics'], 'pubdate': u'2011-11-01', 'title': [u"Modern observations of Hubble's first-discovered Cepheid in M31"], 'abstract': u"We present a modern ephemeris and modern light curve of the first-discovered\nCepheid variable in M31, Edwin Hubble's M31-V1. Observers of the American\nAssociation of Variable Star Observers undertook these observations during the\nlatter half of 2010. The observations were in support of an outreach program by\nthe Space Telescope Science Institute's Hubble Heritage project, but the\nresulting data are the first concentrated observations of M31-V1 made in modern\ntimes. AAVSO observers obtained 214 V-band, Rc-band, and unfiltered\nobservations from which a current ephemeris was derived. The ephemeris derived\nfrom these observations is JD(Max) = 2455430.5(+/-0.5) + 31.4 (+/-0.1) E. The\nperiod derived from the 2010 data are in agreement with the historic values of\nthe period, but the single season of data precludes a more precise\ndetermination of the period or measurement of the period change using these\ndata alone. However, using an ephemeris based upon the period derived by Baade\nand Swope we are able to fit all of the observed data acceptably well.\nContinued observations in the modern era will be very valuable in linking these\nmodern data with data from the 1920s-30s and 1950s, and will enable us to\nmeasure period change in this historic Cepheid. In particular, we strongly\nencourage intensive observations of this star around predicted times of maximum\nto constrain the date of maximum to better than 0.5 days.", u'author': [u'Templeton, M.; Henden, A.; Goff, W.; Smith, S.; Sabo, R.; Walker, G.; Buchheim, R.; Belcheva, G.; Crawford, T.; Cook, M.; Dvorak, S.; Harris, B.']}
+
+ONEREC_FILE = 'test_data/1111/0262'
+
+
+class TestADSArxiv(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.proj_home = os.path.join(os.path.dirname(__file__), '../..')
+        self._app = tasks.app
+        self.app = app_module.AdsArxivCelery('test',local_config={
+            'SQLALCHEMY_URL': 'sqlite:///',
+            'SQLALCHEMY_ECHO': False
+            })
+        tasks.app = self.app # monkey-patch the app object
+
+
+    def test_record_translation(self):
+        test_record = ONEREC_STD
+        test_file = ONEREC_FILE
+
+        with open(test_file,'rU') as fp:
+            parser = arxiv.ArxivParser()
+            indat = parser.parse(fp)
+            outobj = arxivmsg.ArxivToMasterPipeline()
+            outdat = outobj.translate(indat)
+            self.assertEqual(outdat, test_record)
+        
+
+    def test_bad_file_record_translation(self):
+        test_record = ONEREC_STD
+        test_file = 'foo' # does not exist
+
+        with self.assertRaises(IOError):
+            with open(test_file,'rU') as fp:
+                parser = arxiv.ArxivParser()
+                indat = parser.parse(fp)
+                outobj = arxivmsg.ArxivToMasterPipeline()
+                outdat = outobj.translate(indat)
+                self.assertEqual(outdat, test_record)
+
+
+    def test_record_serialization(self):
+        test_record = ONEREC_STD
+        test_file = ONEREC_FILE
+
+        with patch('ADSArxiv.tasks.task_output_results.delay', return_value = None) as next_app:
+            with open(test_file,'rU') as fp:
+                parser = arxiv.ArxivParser()
+                indat = parser.parse(fp)
+                outobj = arxivmsg.ArxivToMasterPipeline()
+                outdat = outobj.translate(indat)
+                output = outobj.serialize(outdat)
+                self.assertTrue(next_app.called)
+
+            indat = {}
+            outobj = arxivmsg.ArxivToMasterPipeline()
+            output = outobj.serialize(indat)
+            self.assertTrue(next_app.called)
+            self.assertTrue(next_app.call_count, 2)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 A worker that generates metadata records from ArXiv.org in .json format
 suitable for conversion to PROTOBUF, and forwards them to RabbitMQ (to
-the queue "arxiv_pipeline/output-results")
+the queue "direct_ingest_pipeline/output-results").
 
-ADSArxiv is intended to be plugged into a generic ADSdirectingest pipeline,
-which could include other pub-specific utilities (e.g. APS, Zenodo).
+ADSArxiv is intended to be plugged into eb-deploy's direct_ingest_pipeline.
+My hope(?) is that there can be multiple workers for publication-specific
+jobs (e.g. APS, Zenodo) that can *all* be plugged in to direct_ingest_pipeline,
+and eliminate the need for separate eb-deploy pipelines for each publication
+(i.e. don't do arxiv_pipeline, aps_pipeline, zenodo_pipeline, etc).

--- a/config.py
+++ b/config.py
@@ -24,12 +24,9 @@ PREFETCH_MULTIPLIER=1
 CELERYD_TASK_SOFT_TIME_LIMIT = 300
 CELERY_BROKER = 'pyamqp://'
 
-CELERY_DEFAULT_EXCHANGE = 'arxiv_pipeline'
+CELERY_DEFAULT_EXCHANGE = 'direct_ingest_pipeline'
 CELERY_DEFAULT_EXCHANGE_TYPE = "topic"
 
-
-# Should this be going to port:6672 ?
-#OUTPUT_CELERY_BROKER = 'pyamqp://guest:guest@localhost:6672/master_pipeline'
 OUTPUT_CELERY_BROKER = 'pyamqp://guest:guest@localhost:5682/master_pipeline'
 
 OUTPUT_TASKNAME = 'adsmp.tasks.task_update_record'

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 addopts = --cov=ADSArxiv --cov-report=term-missing
-testpaths = ADSArxiv/tests
+testpaths = ADSArxiv/tests/


### PR DESCRIPTION
This version of ADSArxiv can be integrated with seasidesparrow/eb-deploy (the direct_ingest_pipeline) to add daily ArXiv updates directly into Solr via master_pipeline.

Test cases are currently passing and covering almost everything.  However, I need to figure out how to test the execution of ADSArxiv.tasks.task_output_results -- nothing I've tried has worked yet.